### PR TITLE
Removes the redundancy in the names of functions and modules involving pulling from KEGG

### DIFF
--- a/src/kegg_pull/make_urls_from_entry_id_list.py
+++ b/src/kegg_pull/make_urls_from_entry_id_list.py
@@ -2,7 +2,7 @@ import logging
 from requests import Response
 
 from src.kegg_pull.kegg_url import ListKEGGurl, GetKEGGurl
-from src.kegg_pull.pull_single_from_kegg import pull_single_from_kegg
+from src.kegg_pull.single_pull import single_pull
 
 MAX_KEGG_ENTRY_IDS_PER_GET_URL: int = 10
 
@@ -48,7 +48,7 @@ def _get_entry_id_list(database_type: str, entry_id_list_path: str) -> list:
 
 def _get_entry_id_list_from_kegg_list_api_operation(database_type: str) -> list:
     list_url = ListKEGGurl(database_type=database_type)
-    res: Response = pull_single_from_kegg(kegg_url=list_url)
+    res: Response = single_pull(kegg_url=list_url)
     entry_ids: list = _parse_entry_ids_string(entry_ids_string=res.text)
 
     # We empirically determined that each line consists of the entry ID followed by more info separated by a tab

--- a/src/kegg_pull/multiple_pull.py
+++ b/src/kegg_pull/multiple_pull.py
@@ -5,11 +5,11 @@ import typing as t
 
 from requests.exceptions import Timeout
 from src.kegg_pull.make_urls_from_entry_id_list import make_urls_from_entry_id_list, GetKEGGurl
-from src.kegg_pull.pull_single_from_kegg import pull_single_from_kegg
+from src.kegg_pull.single_pull import single_pull
 from src.kegg_pull.separate_entries import separate_entries
 
 
-def pull_multiple_from_kegg(
+def multiple_pull(
     output_dir: str, database_type: str = None, entry_id_list_path: str = None, entry_field: str = None,
     n_workers: int = cpu_count()
 ):
@@ -60,7 +60,7 @@ class _MultiThreadedKEGGpuller:
 
     def _pull_and_save(self, get_url: GetKEGGurl):
         try:
-            res: Response = pull_single_from_kegg(kegg_url=get_url)
+            res: Response = single_pull(kegg_url=get_url)
         except Timeout:
             self._timed_out_urls.append(get_url)
 

--- a/src/kegg_pull/single_pull.py
+++ b/src/kegg_pull/single_pull.py
@@ -2,7 +2,7 @@ from src.kegg_pull.kegg_url import AbstractKEGGurl
 from requests import get, Response
 
 
-def pull_single_from_kegg(kegg_url: AbstractKEGGurl, timeout: int = 60, n_tries: int = 3) -> Response:
+def single_pull(kegg_url: AbstractKEGGurl, timeout: int = 60, n_tries: int = 3) -> Response:
     n_times_tried: int = 0
 
     while n_times_tried < n_tries:

--- a/tests/test_make_urls_from_entry_id_list.py
+++ b/tests/test_make_urls_from_entry_id_list.py
@@ -57,7 +57,7 @@ def test_make_urls_from_entry_id_list(mocker):
     database_type = 'compound'
 
     mock_single_pull = _get_mock_single_pull(
-        mocker=mocker, caller_file='make_urls_from_entry_id_list', expected_url=f'{BASE_URL}/list/{database_type}'
+        mocker=mocker, expected_url=f'{BASE_URL}/list/{database_type}'
     )
 
     get_urls: list = make_urls_from_entry_id_list(database_type=database_type)
@@ -67,7 +67,7 @@ def test_make_urls_from_entry_id_list(mocker):
         assert get_kegg_url.url == expected_url
 
 
-def _get_mock_single_pull(mocker, caller_file: str, expected_url: str):
+def _get_mock_single_pull(mocker, expected_url: str):
     mock_response_body = '''
     cpd:C22501	alpha-D-Xylulofuranose
     cpd:C22502	alpha-D-Fructofuranose; alpha-D-Fructose
@@ -91,7 +91,7 @@ def _get_mock_single_pull(mocker, caller_file: str, expected_url: str):
         return mock_response
 
     mock_single_pull = mocker.patch(
-        f'src.kegg_pull.{caller_file}.pull_single_from_kegg',
+        f'src.kegg_pull.make_urls_from_entry_id_list.single_pull',
         wraps=mock_single_pull
     )
 

--- a/tests/test_multiple_pull.py
+++ b/tests/test_multiple_pull.py
@@ -1,5 +1,5 @@
 from src.kegg_pull.kegg_url import BASE_URL, GetKEGGurl, AbstractKEGGurl
-from src.kegg_pull.pull_multiple_from_kegg import pull_multiple_from_kegg
+from src.kegg_pull.multiple_pull import multiple_pull
 
 import pytest
 from pickle import load, dump
@@ -23,13 +23,13 @@ def setup_and_teardown():
 
 # TODO: Test with timeout
 # TODO: Test with failures
-def test_pull_multiple_from_kegg(mocker, setup_and_teardown):
+def test_multiple_pull(mocker, setup_and_teardown):
     actual_urls_dir, mock_output_dir = setup_and_teardown
     mock_get_urls, expected_successful_entry_ids = _mock_input_output()
     expected_urls = {url.url for url in mock_get_urls}
 
     mock_make_urls_from_entry_id_list = mocker.patch(
-        'src.kegg_pull.pull_multiple_from_kegg.make_urls_from_entry_id_list', return_value=mock_get_urls
+        'src.kegg_pull.multiple_pull.make_urls_from_entry_id_list', return_value=mock_get_urls
     )
 
     def mock_single_pull(kegg_url: AbstractKEGGurl):
@@ -41,12 +41,12 @@ def test_pull_multiple_from_kegg(mocker, setup_and_teardown):
         return res
 
     mocker.patch(
-        'src.kegg_pull.pull_multiple_from_kegg.pull_single_from_kegg', wraps=mock_single_pull
+        'src.kegg_pull.multiple_pull.single_pull', wraps=mock_single_pull
     )
 
     mock_database_type = 'mock-database-type'
 
-    successful_entry_ids, failed_entry_ids = pull_multiple_from_kegg(
+    successful_entry_ids, failed_entry_ids = multiple_pull(
         output_dir=mock_output_dir, database_type=mock_database_type, n_workers=len(mock_get_urls)
     )
 

--- a/tests/test_single_pull.py
+++ b/tests/test_single_pull.py
@@ -1,12 +1,12 @@
 from src.kegg_pull.kegg_url import ListKEGGurl
-from src.kegg_pull.pull_single_from_kegg import pull_single_from_kegg
+from src.kegg_pull.single_pull import single_pull
 
 
 # TODO: Test a failure
 # TODO: Test a Timeout
-def test_pull_single_from_kegg(mocker):
+def test_single_pull(mocker):
     mock_get_return_value = mocker.MagicMock(status_code=200)
-    mock_get = mocker.patch('src.kegg_pull.pull_single_from_kegg.get', return_value=mock_get_return_value)
+    mock_get = mocker.patch('src.kegg_pull.single_pull.get', return_value=mock_get_return_value)
     list_url = ListKEGGurl(database_type='rclass')
-    pull_single_from_kegg(kegg_url=list_url)
+    single_pull(kegg_url=list_url)
     mock_get.assert_called_once_with(list_url.url, timeout=60)


### PR DESCRIPTION
closes #13 