### PR TITLE
Add BioConda recipe

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,13 +13,22 @@ Installation
 ------------
 Requires python 3.10 and above.
 
-Install on Linux, Mac OS X
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+Using conda
+~~~~~~~~~~~
+
+.. parsed-literal::
+   conda install -c bioconda kegg_pull
+
+Using pip
+~~~~~~~~~
+
+**For Linux, Mac OS X:**
+
 .. parsed-literal::
    python3 -m pip install kegg-pull
 
-Install on Windows
-~~~~~~~~~~~~~~~~~~
+**For Windows:**
+
 .. parsed-literal::
    py -3 -m pip install kegg-pull
 
@@ -36,13 +45,18 @@ PyPi
 ~~~~
 See our PyPi page `here <https://pypi.org/project/kegg-pull/>`__.
 
+BioConda
+~~~~~~~~
+
+See our BioConda page `here <https://anaconda.org/channels/bioconda/packages/kegg_pull/overview>`__.
+
 Questions, Feature Requests, and Bug Reports
 --------------------------------------------
 Please submit any questions or feature requests you may have and report any potential bugs/errors you observe on `our GitHub issues page <https://github.com/MoseleyBioinformaticsLab/kegg_pull/issues>`__.
 
 Dependencies
 ------------
-Note, the ``pip`` command will install dependencies automatically.
+Note, the ``pip`` and ``conda`` commands will install dependencies automatically.
 
 .. parsed-literal::
    docopt

--- a/bioconda_recipe/meta.yaml
+++ b/bioconda_recipe/meta.yaml
@@ -1,0 +1,48 @@
+{% set name = "kegg_pull" %}
+{% set version = "3.2.2" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: ce948881378e5d6d44a8d3a6b85f46c10dd07dcc7000195d71a77fe3082f85f6
+
+build:
+  number: 0
+  noarch: python
+  entry_points:
+    - kegg_pull = kegg_pull.__main__:main
+  script: "{{ PYTHON }} -m pip install . -vvv --no-deps --no-build-isolation --no-cache-dir"
+  run_exports:
+    - {{ pin_subpackage('kegg_pull', max_pin="x") }}
+
+requirements:
+  host:
+    - python >=3.10
+    - pip
+    - setuptools
+  run:
+    - python >=3.10
+    - docopt
+    - requests
+    - tqdm
+    - jsonschema
+
+test:
+  commands:
+    - kegg_pull -h
+
+about:
+  home: "https://github.com/MoseleyBioinformaticsLab/kegg_pull"
+  license: Clear BSD License with Extra Clause
+  license_family: BSD
+  license_file: LICENSE
+  summary: "Package that facilitates pulling database entries from KEGG via its REST API "
+  doc_url: "https://moseleybioinformaticslab.github.io/kegg_pull/index.html"
+  dev_url: "https://github.com/MoseleyBioinformaticsLab/kegg_pull"
+
+extra:
+  recipe-maintainers:
+    - LucoDevro


### PR DESCRIPTION
Hi Erik,

Thanks a lot for developing this tool! Getting many KEGG records in a ready-to-use form this efficiently is an underestimated challenge.

I'm relying on `kegg_pull` as the KEGG API in my new gene cluster mining tool [`cfoldseeker`](https://github.com/LucoDevro/cfoldseeker). I'm about to release it on BioConda. `kegg_pull` was the only dependency not available on BioConda yet, so I made a BioConda recipe and submitted it for inclusion in BioConda.

`kegg_pull` is now also available from BioConda! With this PR, I'm attaching the BioConda recipe to the repo as well as adding installation instructions from BioConda in the README.

Unless you'd change its dependencies, there is no need to update the recipe manually at BioConda with every update of kegg_pull. BioConda's bot will do so with every update of your PyPi package. You'd only need to copy over the recipe here if you'd like to keep it up to date in kegg_pull's repo too. Let me know if you like to be added as recipe maintainer so you get notifications from BioConda as well and can submit manual recipe edits yourself.